### PR TITLE
Fix: Preserve 'Igor' capitalization in titles

### DIFF
--- a/Redirect/shared.py
+++ b/Redirect/shared.py
@@ -40,7 +40,10 @@ def truncate_text(text: str, max_chars: int) -> str:
 def humanize_url_part(s):
     if s is None:
         return ""
-    return s.replace("-", " ").capitalize()
+    text = s.replace("-", " ").capitalize()
+    # Keep Igor capitalized
+    text = text.replace("igor", "Igor")
+    return text
 
 
 # short alias

--- a/modal_redirect.py
+++ b/modal_redirect.py
@@ -57,7 +57,10 @@ def truncate_text(text: str, max_chars: int) -> str:
 def humanize_url_part(s):
     if s is None:
         return ""
-    return s.replace("-", " ").capitalize()
+    text = s.replace("-", " ").capitalize()
+    # Keep Igor capitalized
+    text = text.replace("igor", "Igor")
+    return text
 
 
 # short alias
@@ -186,16 +189,16 @@ def generate_title(page, anchor):
         return "Igor's book of management"
     elif page == "manager-book" and anchor:
         # Special handling for manager-book
-        anchor_text = anchor.replace("-", " ").capitalize()
+        anchor_text = hup(anchor)
         return f"{anchor_text} (Igor's Manager Book)"
     elif anchor:
         # Capitalize and replace hyphens with spaces
-        anchor_text = anchor.replace("-", " ").capitalize()
-        page_text = page.replace("-", " ").capitalize()
+        anchor_text = hup(anchor)
+        page_text = hup(page)
         return f"{anchor_text} ({page_text})"
     else:
         # Just the page
-        return page.replace("-", " ").capitalize()
+        return hup(page)
 
 
 def get_html_for_redirect_simple(title, page, anchor):


### PR DESCRIPTION
## Summary
- Keep "Igor" properly capitalized wherever it appears in titles
- Use `hup()` function consistently in `generate_title()` to avoid code duplication
- Add special handling in `humanize_url_part()` to preserve proper names

## Test plan
- [x] All existing tests pass
- [x] Verified that "Igor" stays capitalized in titles like "Ask Igor questions"
- [x] Confirmed backward compatibility with existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)